### PR TITLE
Add a dependency on the "result" package

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -50,6 +50,7 @@
       (ocaml (>= 4.07.0))
       (session-cookie (= :version))
       async
+      result
       (alcotest :with-test)
       (junit :with-test)
       (junit_alcotest :with-test)
@@ -64,6 +65,7 @@
       (ocaml (>= 4.07.0))
       (session-cookie (= :version))
       lwt
+      result
       (alcotest :with-test)
       (junit :with-test)
       (junit_alcotest :with-test)

--- a/session-cookie-async.opam
+++ b/session-cookie-async.opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "session-cookie" {= version}
   "async"
+  "result"
   "alcotest" {with-test}
   "junit" {with-test}
   "junit_alcotest" {with-test}

--- a/session-cookie-lwt.opam
+++ b/session-cookie-lwt.opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "session-cookie" {= version}
   "lwt"
+  "result"
   "alcotest" {with-test}
   "junit" {with-test}
   "junit_alcotest" {with-test}


### PR DESCRIPTION
This fixes a build error in switches where "result" is not installed, and makes it possible to build this project with dune package management.